### PR TITLE
[links] [UX] Add links to themes and plugins pages on data cleanup.

### DIFF
--- a/freemius-fixer.php
+++ b/freemius-fixer.php
@@ -217,7 +217,21 @@
 
         deactivate_plugins( plugin_basename( __FILE__ ) );
 
-        wp_die( __( 'Freemius records successfully cleared! You are now safe to activate any Freemius-powered plugin or theme.' ), __( 'Error' ) );
+        $plugins_url = admin_url( 'plugins.php' );
+	    $themes_url  = admin_url( 'themes.php' );
+
+	    if ( is_multisite() && is_network_admin() ) {
+		    $plugins_url = network_admin_url( 'plugins.php' );
+		    $themes_url  = network_admin_url( 'themes.php' );
+	    }
+
+	    wp_die(
+		    __(
+			    'Freemius records successfully cleared! You are now safe to activate any Freemius-powered'
+		    ) . ' <a href="' . esc_url( $plugins_url ) . '">' . __( 'plugin' ) . '</a> ' . __( 'or' ) .
+		    ' <a href="' . esc_url( $themes_url ) . '">' . __( 'theme' ) . '</a>.',
+		    __( 'Success' )
+	    );
     }
 
     add_action( 'activated_plugin', 'fs_cleanup_activation_redirect_to_settings_page' );


### PR DESCRIPTION
Add links to themes and plugins pages on data cleanup for better UX. 

## Why?
It is easy to get lost once the data is cleaned up for external users. This solution creates a link to the next action.

# Screenshots
## Before
![CleanShot 2024-12-17 at 13 36 44](https://github.com/user-attachments/assets/6356cc63-b1ad-46da-924d-96f7b6d88ec1)

## After
![CleanShot 2024-12-17 at 13 35 35](https://github.com/user-attachments/assets/b8de9360-bd27-40fb-94a8-158956cc53e7)
